### PR TITLE
fix: manual form submit

### DIFF
--- a/src/app/RegistrationForm.tsx
+++ b/src/app/RegistrationForm.tsx
@@ -92,7 +92,12 @@ export const RegistrationForm = ({
       <form
         ref={formRef}
         action={formAction}
-        onSubmit={form.handleSubmit(() => formRef?.current?.submit())}
+        onSubmit={(evt) => {
+          evt.preventDefault();
+          form.handleSubmit(() => {
+            formAction(new FormData(formRef.current!));
+          })(evt);
+        }}
         className="space-y-8"
       >
         <div className="flex gap-2">


### PR DESCRIPTION
**Description**
This PR addresses an issue encountered during the form submit process when utilizing the `useFormState` hook and manually initiating submit using `formRef?.current?.submit()`. The current implementation triggers an unexpected submit error, as evidenced by the attached screenshot of the error stack trace.

**Related Issue**
[ISSUE](https://github.com/ProNextJS/forms-management/issues/2)

**Changes Made**
- (info) preserved the `action={formAction}` attribute, as it is essential for server-side validation in cases where JavaScript is disabled
- (changes) prevented default HTML form submission behavior, followed by the explicit triggering of form.handleSubmit to initiate the submission process programmatically. 

**Screenshot**
![Screenshot 2024-04-11 at 1 10 00 PM 2](https://github.com/ProNextJS/forms-management/assets/46320739/bcbbc7b6-6e3d-4cb3-9706-55b8ea50740e)
